### PR TITLE
Add curve25519-sha256@libssh.org into sshd configuration

### DIFF
--- a/etc/ssh/sshd_config
+++ b/etc/ssh/sshd_config
@@ -8,7 +8,7 @@ HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 
 Ciphers aes256-ctr
-KexAlgorithms diffie-hellman-group-exchange-sha256,curve25519-sha256
+KexAlgorithms diffie-hellman-group-exchange-sha256,curve25519-sha256,curve25519-sha256@libssh.org
 Macs hmac-sha2-512-etm@openssh.com
 
 RekeyLimit default 1h


### PR DESCRIPTION
## Fixes
 -  Add curve25519-sha256@libssh.org into sshd configuration, build error otherwise (ssh client on FreeBSD cannot connect )