### PR TITLE
IMPCAP TEMPLATE:: add template for new rsyslog's omhiredis 'set' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,124 @@
+# Created by https://www.gitignore.io/api/vim,code,pycharm
+# Edit at https://www.gitignore.io/?templates=vim,code,pycharm
+
+### Code ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
+# End of https://www.gitignore.io/api/vim,code,pycharm

--- a/usr/local/etc/rsyslog.d/05-tpl-02-impcap.conf
+++ b/usr/local/etc/rsyslog.d/05-tpl-02-impcap.conf
@@ -2,7 +2,9 @@
 template(name="impcap_darwin_object" type="string" string="{\"qname\":\"%$.name!qname%\",\"type\":\"%$.name!type%\",\"qtype\":\"%$.name!qtype%\",\"class\":\"%$.name!class%\",\"qclass\":\"%$.name!qclass%\",\"darwin_decision\":\"%$!dga%\"},")
 
 template(name="impcap_redis_cache" type="string" string="SETEX %$!mmdarwin!darwin_id% 60 %$!impcap_cache%")
+template(name="impcap_redis_key" type="string" string="%$!mmdarwin!darwin_id%")
 
+# Will become obsolete when rsyslog redis update ('set' option) is widely used
 template(name="impcap_redis" type="list") {
     constant(value="{")
     property(name="$!impcap!timestamp" outname="time" format="jsonf" datatype="string" dateformat="rfc3339") constant(value=",")


### PR DESCRIPTION
- new template line to allow new configurations in darwin rulesets, when Rsyslog's omhiredis handles 'set' mode
- add .gitignore for vscode, pycharm, vim