### PR TITLE
FIX MKJAIL REPOSITORY

### DIFF
--- a/home/vlt-adm/bootstrap/mkjail-apache.sh
+++ b/home/vlt-adm/bootstrap/mkjail-apache.sh
@@ -90,7 +90,7 @@ done
 /bin/echo "Ok!"
 
 /bin/echo -n "Updating pkg repositories..."
-/bin/cp /var/db/pkg/repo-FreeBSD.sqlite ${TARGET}/var/db/pkg/
+/bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"
 
 # Start jail

--- a/home/vlt-adm/bootstrap/mkjail-apache.sh
+++ b/home/vlt-adm/bootstrap/mkjail-apache.sh
@@ -89,6 +89,12 @@ done
 
 /bin/echo "Ok!"
 
+/bin/echo -n "Adding vulture project repositories..."
+/bin/cp /usr/share/keys/pkg/trusted/pkg.vultureproject.org ${TARGET}/usr/share/keys/pkg/trusted/
+/bin/cp /usr/local/etc/pkg/repos/vulture.conf ${TARGET}/usr/local/etc/pkg/repos/
+/usr/sbin/pkg -j ${JAIL} update -f
+/bin/echo "Ok !"
+
 /bin/echo -n "Updating pkg repositories..."
 /bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"

--- a/home/vlt-adm/bootstrap/mkjail-mongodb.sh
+++ b/home/vlt-adm/bootstrap/mkjail-mongodb.sh
@@ -90,7 +90,7 @@ fi
 /bin/echo "Ok!"
 
 /bin/echo -n "Updating pkg repositories..."
-/bin/cp /var/db/pkg/repo-FreeBSD.sqlite ${TARGET}/var/db/pkg/
+/bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"
 
 # Start jail

--- a/home/vlt-adm/bootstrap/mkjail-portal.sh
+++ b/home/vlt-adm/bootstrap/mkjail-portal.sh
@@ -89,7 +89,7 @@ done
 /bin/echo "Ok!"
 
 /bin/echo -n "Updating pkg repositories..."
-/bin/cp /var/db/pkg/repo-FreeBSD.sqlite ${TARGET}/var/db/pkg/
+/bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"
 
 # Start jail

--- a/home/vlt-adm/bootstrap/mkjail-redis.sh
+++ b/home/vlt-adm/bootstrap/mkjail-redis.sh
@@ -104,7 +104,7 @@ for service in "redis" "sentinel" ; do
 done
 
 /bin/echo -n "Updating pkg repositories..."
-/bin/cp /var/db/pkg/repo-FreeBSD.sqlite ${TARGET}/var/db/pkg/
+/bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"
 
 # Start jail

--- a/home/vlt-adm/bootstrap/mkjail-rsyslog.sh
+++ b/home/vlt-adm/bootstrap/mkjail-rsyslog.sh
@@ -95,7 +95,7 @@ echo 'rsyslogd_config="/usr/local/etc/rsyslog.conf"' >> ${TARGET}/etc/rc.conf.d/
 /bin/echo "Ok!"
 
 /bin/echo -n "Updating pkg repositories..."
-/bin/cp /var/db/pkg/repo-FreeBSD.sqlite ${TARGET}/var/db/pkg/
+/bin/cp /var/db/pkg/repo-HardenedBSD.sqlite ${TARGET}/var/db/pkg/
 /bin/echo "Ok !"
 
 # Start jail


### PR DESCRIPTION
The Vulture pkg repositories where not available inside the apache jail.
Thus vulture-dashboard install was failing.

Since we moved to HardenedBSD the sqlite pkg db name changed:
`/var/db/pkg/repo-FreeBSD.sqlite` -> `repo-HardenedBSD.sqlite`