### PR TITLE
ADDING SECADM SERVICE ENBLING & RULES

### DIFF
--- a/home/vlt-adm/bootstrap/install-kernel.sh
+++ b/home/vlt-adm/bootstrap/install-kernel.sh
@@ -38,12 +38,3 @@ sysctl kern.geom.confdot | sed -n 's/^.*hexagon,label="\([^\]*\)\\n\([^\]*\).*/\
 DISKSLICE=`cat /tmp/DISKSLICE_$$`
 echo "Install Vulture-OS bootcode on ${DISKSLICE}"
 gpart bootcode -b /boot/pmbr -p /boot/gptzfsboot -i 1 ${DISKSLICE}
-
-# Restart secadm to load new rules
-/usr/sbin/service secadm restart
-
-# Deploy secadm config in jails that need exceptions
-cp /usr/local/etc/secadm-apache.rules /zroot/apache/usr/local/etc/secadm.rules
-
-# Restart secadm in jails that need exceptions
-jexec apache service secadm restart

--- a/home/vlt-adm/bootstrap/mkjail-apache.sh
+++ b/home/vlt-adm/bootstrap/mkjail-apache.sh
@@ -211,6 +211,10 @@ done
 #Cleanup
 rm -f /zroot/*/var/cache/pkg/*
 
+# Enabling secadm
+jexec ${JAIL} sysrc secadm_enable=YES
+jexec ${JAIL} service secadm start
+
 #Crontab is not used - disable it
 #Note: We can't disable it sooner in mkjail, otherwise jail won't start
 #jexec ${JAIL} sysrc cron_enable=NO

--- a/home/vlt-adm/bootstrap/mkjail-mongodb.sh
+++ b/home/vlt-adm/bootstrap/mkjail-mongodb.sh
@@ -140,6 +140,9 @@ fi
 #Cleanup
 rm -f /zroot/*/var/cache/pkg/*
 
+# Enabling secadm
+jexec ${JAIL} sysrc secadm_enable=YES
+jexec ${JAIL} service secadm start
 
 #Crontab is not used - disable it
 #Note: We can't disable it sooner in mkjail, otherwise jail won't start

--- a/home/vlt-adm/bootstrap/mkjail-portal.sh
+++ b/home/vlt-adm/bootstrap/mkjail-portal.sh
@@ -193,6 +193,10 @@ done
 #Cleanup
 rm -f /zroot/*/var/cache/pkg/*
 
+# Enabling secadm
+jexec ${JAIL} sysrc secadm_enable=YES
+jexec ${JAIL} service secadm start
+
 #Crontab is not used - disable it
 #Note: We can't disable it sooner in mkjail, otherwise jail won't start
 #jexec ${JAIL} sysrc cron_enable=NO

--- a/usr/local/etc/secadm.rules
+++ b/usr/local/etc/secadm.rules
@@ -1,0 +1,14 @@
+secadm {
+	pax {
+		path: "/usr/home/jails.apache/.zfs-source/home/vlt-os/env/bin/python3.7",
+		mprotect: false,
+		pageexec: false,
+		prefer_acl: true
+	},
+    pax {
+        path: "/usr/local/bootstrap-openjdk11/bin/java",
+        mprotect: false,
+        pageexec: false,
+        prefer_acl: true
+    }
+}


### PR DESCRIPTION
Adding the secadm.rules for the installed software (ex. zap).

Removing apache jails rules copy because it is now installe by vulture-gui.
This goes with removing secadm service starting that is now useless in the
install-kernel.sh.

Because of the reasons given above we do need to enable secadm earlier in the
bootstraping process.
This is why we modified some mkjails to enable and start secadm.