### PR TITLE
Release 1.0.4

### DIFF
--- a/etc/cron.d/logrotate
+++ b/etc/cron.d/logrotate
@@ -4,4 +4,4 @@ SHELL=/bin/sh
 PATH=/etc:/bin:/sbin:/usr/bin:/usr/sbin
 
 # See crontab(5) for field format.
-1	*	*	*	*	root	/usr/local/sbin/logrotate -f /usr/local/etc/logrotate.conf
+1	*	*	*	*	root	/usr/local/sbin/logrotate /usr/local/etc/logrotate.conf

--- a/home/vlt-adm/bootstrap/install-kernel.sh
+++ b/home/vlt-adm/bootstrap/install-kernel.sh
@@ -38,3 +38,6 @@ sysctl kern.geom.confdot | sed -n 's/^.*hexagon,label="\([^\]*\)\\n\([^\]*\).*/\
 DISKSLICE=`cat /tmp/DISKSLICE_$$`
 echo "Install Vulture-OS bootcode on ${DISKSLICE}"
 gpart bootcode -b /boot/pmbr -p /boot/gptzfsboot -i 1 ${DISKSLICE}
+
+# Restart secadm after rules update
+/usr/sbin/service secadm restart

--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -159,8 +159,10 @@
 	missingok
 	rotate 24
 	compress
-	delaycompress
+	nodelaycompress
 	notifempty
+	dateext
+	dateformat .%Y-%m-%dT%H.gz
 	create 0640 vlt-os wheel
 	sharedscripts  # execute script one time for all logs
 	postrotate

--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -157,12 +157,11 @@
 	su root wheel
 	hourly
 	missingok
-	rotate 24
+	copytruncate  # Permit to prevent restarting
+	rotate 10      # Keep last 10h
 	compress
-	nodelaycompress
+	delaycompress
 	notifempty
-	dateext
-	dateformat .%Y-%m-%dT%H.gz
 	create 0640 vlt-os wheel
 	sharedscripts  # execute script one time for all logs
 	postrotate

--- a/usr/local/etc/secadm.rules
+++ b/usr/local/etc/secadm.rules
@@ -6,6 +6,12 @@ secadm {
 		prefer_acl: true
 	},
     pax {
+		path: "/usr/local/bin/python3.7",
+		mprotect: false,
+		pageexec: false,
+		prefer_acl: true
+	},
+    pax {
         path: "/usr/local/bootstrap-openjdk11/bin/java",
         mprotect: false,
         pageexec: false,


### PR DESCRIPTION
### Improvements
 - SECADM : Add system python binary in secadm exceptions
 - UPDATE : Add support for HardenedBSD upgrade

### Fixes
 - LOGROTATE : Add copytruncate option for api logs to prevent file system increase + rotate only 10 hours instead of 24
  - INSTALL_KERNEL : Restart secadm after vulture-base install to load new rules
