### PR TITLE
Release 1.0.5

### DIFF
--- a/boot/loader.conf
+++ b/boot/loader.conf
@@ -3,7 +3,12 @@ geom_eli_load="YES"
 zfs_load="YES"
 carp_load="YES"
 if_tap_load="YES"
+if_vlan_load="YES"
 secadm_load="YES"
+net.fibs=2
+
+#This is to avoid kernel panic on HP Proliant server at boot
+vm.boot_pages=120
 
 #This is for Amazon EC3, disable if useless
 if_ena_load="YES"

--- a/home/vlt-adm/system/proxy.sh
+++ b/home/vlt-adm/system/proxy.sh
@@ -15,6 +15,10 @@ if [ "${proxy}" != "" ]; then
     /bin/echo "http_proxy=http://${proxy}" > /etc/rc.conf.proxy
     /bin/echo "https_proxy=http://${proxy}" >> /etc/rc.conf.proxy
     /bin/echo "ftp_proxy=http://${proxy}" >> /etc/rc.conf.proxy
+    # Copy proxy conf to jails
+    for dir in /zroot/*/etc/ ; do /bin/cp /etc/rc.conf.proxy "$dir" ; done
 else
     /bin/rm /etc/rc.conf.proxy
+    # Remove proxy from jails
+    /bin/rm /zroot/*/etc/rc.conf.proxy
 fi

--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -23,6 +23,12 @@ update_system() {
         if [ -n "$jail" ] ; then options="-D -j $jail" ; fi
         # Store (-t) and keep (-T) downloads to $temp_dir for later use
         /usr/sbin/hbsd-update -t "$temp_dir" -T $options > /dev/null
+        # Restart secadm service after updating Hardened kernel
+        if [ -n "$jail" ] ; then 
+            /usr/sbin/jexec $jail /usr/sbin/service secadm restart
+        else
+            /usr/sbin/service secadm restart
+        fi
     else
         # If jail, just install do not fetch
         if [ -n "$jail" ] ; then options="-b /zroot/$jail" ; else option="fetch" ; fi

--- a/home/vlt-adm/system/write_hostname.sh
+++ b/home/vlt-adm/system/write_hostname.sh
@@ -34,6 +34,10 @@ ip="$(/bin/cat /usr/local/etc/management.ip)"
 /bin/echo "${ip} ${hostname}" >> /etc/hosts
 /bin/echo "${hostname}" > /etc/host-hostname
 
+# Set hostname=127.0.0.2 into MongoDB jail - it can then resolve himself
+/bin/cp /etc/hosts /zroot/mongodb/etc/hosts
+/usr/bin/sed -i '' "s/$ip/127.0.0.2/" /zroot/mongodb/etc/hosts
+
 #Copy hosts file to jails
 for jail in apache mongodb redis rsyslog haproxy portal; do
     /bin/cp /usr/local/etc/management.ip /zroot/${jail}/usr/local/etc/management.ip

--- a/usr/local/bin/pfctl-init.sh
+++ b/usr/local/bin/pfctl-init.sh
@@ -73,6 +73,12 @@ ${REMOTE_TO_JAIL}
 
 # Generic directives
 pass quick on lo0 all
+pass quick on lo1 all
+pass quick on lo2 all
+pass quick on lo3 all
+pass quick on lo4 all
+pass quick on lo5 all
+pass quick on lo6 all
 block in log all
 #pass in proto icmp6 all
 #pass out proto icmp6 all

--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -158,7 +158,7 @@
 	hourly
 	missingok
 	copytruncate  # Permit to prevent restarting
-	rotate 10      # Keep last 10h
+	rotate 10
 	compress
 	delaycompress
 	notifempty


### PR DESCRIPTION
## Improvements / New features
 - BOOT LOADER :  Add VLAN support, allow 2 routing tables and fix HP Proliant kernel panic at boot

## Fixes
 - ADMIN : Copy proxy configuration to jails
 - ADMIN : Restart secadm service after kernel upgrade
 - LOGROTATE : Fix typo in configuration file
 - MONGODB : Add hostname=127.0.0.2 in mongodb hosts file to prevent bad status
 - PF : Add missing pass directives for internal jails communications, in initial pf configuration file
