### PR TITLE
Release 1.1.9

### DIFF
--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -64,7 +64,7 @@
 	compress
 	delaycompress
 	notifempty
-	create 0644 vlt-os vlt-web
+	copytruncate  # Mandatory for django crontabs logs
 	sharedscripts  # execute script one time for all logs
 	postrotate
 	    /usr/sbin/service vultured restart


### PR DESCRIPTION
### Fixed
 - **[LOGROTATE]** : Use copytruncate for python logs (*/var/log/vulture/os/**.log* -> some logs where lost -> django crontabs continued to write into rotated file
