### PR TITLE
Release 1.2.0

### DIFF
--- a/home/vlt-adm/bootstrap/mkjail-portal.sh
+++ b/home/vlt-adm/bootstrap/mkjail-portal.sh
@@ -81,10 +81,7 @@ for option in "syslogd_enable" "sendmail_enable" "sendmail_submit_enable" \
     fi
 done
 
-/bin/echo 'apache24_enable="YES"' > ${TARGET}/etc/rc.conf.d/apache24
-/bin/echo 'apache24_http_accept_enable="YES"' >> ${TARGET}/etc/rc.conf.d/apache24
-/bin/echo 'apache24_profiles="portal"' >> ${TARGET}/etc/rc.conf.d/apache24
-/bin/echo 'apache24_portal_configfile="/usr/local/etc/apache24/portal-httpd.conf"' >> ${TARGET}/etc/rc.conf.d/apache24
+/bin/echo 'gunicorn_enable="YES"' > ${TARGET}/etc/rc.conf.d/gunicorn
 
 /bin/echo "Ok!"
 
@@ -103,8 +100,6 @@ jexec ${JAIL} /usr/sbin/pwd_mkdb -p /etc/master.passwd
 /bin/echo "Installing packages into jail... Please be patient"
 
 /usr/sbin/pkg -j ${JAIL} install -y wget || (/bin/echo "Fail !" ; exit 1)
-/usr/sbin/pkg -j ${JAIL} install -y apache24 || (/bin/echo "Fail !" ; exit 1)
-/usr/sbin/pkg -j ${JAIL} install -y ap24-py38-mod_wsgi || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y openldap24-client || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y krb5 || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y radiusclient || (/bin/echo "Fail !" ; exit 1)

--- a/home/vlt-adm/system/hostname.sh
+++ b/home/vlt-adm/system/hostname.sh
@@ -59,7 +59,7 @@ if [ -f /tmp/bsdinstall_etc/rc.conf.hostname ]; then
 
         # Apache: Hostname change has no impact
         /usr/sbin/jexec apache /usr/sbin/service apache24 restart
-        /usr/sbin/jexec portal /usr/sbin/service apache24 restart
+        /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
 
         # MongoDB is restarted "as this"
         if ! /usr/sbin/jexec mongodb /usr/sbin/service mongod restart ; then

--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -121,7 +121,7 @@ if [ -z "$1" -o "$1" == "gui" ] ; then
     update_system "$temp_dir" "portal"
     echo "Ok."
     /usr/sbin/jexec apache /usr/sbin/service apache24 restart
-    /usr/sbin/jexec portal /usr/sbin/service apache24 restart
+    /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
     echo "[+] GUI updated."
 fi
 

--- a/home/vlt-adm/system/update_system_lite.sh
+++ b/home/vlt-adm/system/update_system_lite.sh
@@ -87,7 +87,7 @@ if [ -z "$1" -o "$1" == "gui" ] ; then
     IGNORE_OSVERSION="yes" /usr/sbin/pkg -j apache upgrade -y
     IGNORE_OSVERSION="yes" /usr/sbin/pkg -j portal upgrade -y
     /usr/sbin/jexec apache /usr/sbin/service apache24 restart
-    /usr/sbin/jexec portal /usr/sbin/service apache24 restart
+    /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
     echo "[+] GUI updated."
 fi
 

--- a/sbin/pkg
+++ b/sbin/pkg
@@ -1,0 +1,22 @@
+#!/bin/csh
+
+set allowed=1
+foreach arg ($*)
+    if ( "$arg" == "upgrade" ) then
+        set allowed=0
+    endif
+end
+
+if ( $allowed ) then
+    /usr/sbin/pkg $*
+else
+    cat - << EOF
+[1m[38;5;196m    *** Administration restriction ***
+[1m[38;5;196m    Don't use this command until you know what you're doing
+[0m[1m To upgrade you're Vulture, please instead use the following commands :
+[1m[38;5;33m o update_system          (/home/vlt-adm/system/update_system.sh)
+[1m[38;5;33m o update_system_lite     (/home/vlt-adm/system/update_system_lite.sh)
+[0m
+
+EOF
+endif

--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -69,7 +69,7 @@
 	postrotate
 	    /usr/sbin/service vultured restart
 	    /usr/sbin/jexec apache /usr/sbin/service apache24 reload
-	    /usr/sbin/jexec portal /usr/sbin/service apache24 reload
+	    /usr/sbin/jexec portal /usr/sbin/service gunicorn reload
 	endscript
 }
 

--- a/usr/local/etc/sudoers.d/vulture_sudoers
+++ b/usr/local/etc/sudoers.d/vulture_sudoers
@@ -12,7 +12,7 @@ vlt-os ALL=NOPASSWD:/usr/sbin/service routing restart
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec redis /usr/sbin/service redis onestatus
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec mongodb /usr/sbin/service mongod onestatus
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 onestatus
-vlt-os ALL=NOPASSWD:/usr/sbin/jexec portal /usr/sbin/service apache24 onestatus
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec portal /usr/sbin/service gunicorn onestatus
 
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 reload
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 restart


### PR DESCRIPTION
### Added
 - [ADMIN][Restriction] Prevent (mis)use of `pkg upgrade` (use `update_system(_lite).sh` instead)

### Changed
 - [PORTAL] Use **[gunicorn](https://docs.gunicorn.org/en/stable/)** instead of **[apache wsgi](https://pypi.org/project/mod-wsgi/)** to host portal engine
