### PR TITLE
Version 1.2.2

### DIFF
--- a/home/vlt-adm/bootstrap/mkjail-apache.sh
+++ b/home/vlt-adm/bootstrap/mkjail-apache.sh
@@ -116,9 +116,16 @@ jexec ${JAIL} /usr/sbin/pwd_mkdb -p /etc/master.passwd
 /usr/sbin/pkg -j ${JAIL} install -y secadm secadm-kmod || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y liblognorm || (/bin/echo "Fail !" ; exit 1)
 
-#Haproxy is needed inside the jail to test haproxy configuration (1.9.0 minimum required)
-/usr/sbin/pkg -j ${JAIL} install -y haproxy || (/bin/echo "Fail !" ; exit 1)
+# Needed dependency for haproxy package copied from vulture-haproxy
+/usr/sbin/pkg -j ${JAIL} install -y pcre2 || (/bin/echo "Fail !" ; exit 1)
 /bin/echo "Ok !"
+
+# Copy needed files from vulture-haproxy package to apache jail
+mkdir -p /zroot/apache/usr/local/sbin
+mkdir -p /zroot/apache/usr/local/lib
+/bin/cp -Rpf /home/jails.haproxy/.zfs-source/usr/local/sbin/haproxy /zroot/apache/usr/local/sbin/haproxy
+/bin/cp -Rpf /home/jails.haproxy/.zfs-source/usr/local/lib/libslz.* /zroot/apache/usr/local/lib/
+
 
 # Jail NEEDS to be modified after system file modification !!!
 /bin/echo -n "Syncing jail..."

--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -71,6 +71,11 @@ for jail in "haproxy" "redis" "mongodb" "rsyslog" ; do
                 ;;
             mongodb)
                 /usr/sbin/jexec "$jail" /usr/sbin/service mongod restart
+                # TODO Force disable pageexec and mprotect on the mongo executable
+                # there seems to be a bug currently with secadm when rules are pre-loaded on executables in packages
+                # which is the case for latest mongodb36-3.6.23
+                /usr/sbin/jexec "$jail" /usr/sbin/hbsdcontrol pax disable pageexec /usr/local/bin/mongo
+                /usr/sbin/jexec "$jail" /usr/sbin/hbsdcontrol pax disable mprotect /usr/local/bin/mongo
                 ;;
             redis)
                 /usr/sbin/jexec "$jail" /usr/sbin/service sentinel stop


### PR DESCRIPTION
### Added
- [UPGRADE_SCRIPT][MONGO] ensure secadm exceptions are enforced for `mongo` executable in mongodb jail
- [BOOTSTRAP] Install vulture-haproxy binary dependencies to apache jail (pcre2)
- [BOOTSTRAP] copy haproxy binary and libraries from vulture-haproxy package to apache jail

### Removed
- [BOOTSTRAP] Don't install haproxy package to apache jail