### PR TITLE
CLOUDINIT::ADDED:: Files for cloudinit integration

### DIFF
--- a/usr/local/etc/cloud/cloud.cfg.d/02_growpart.cfg
+++ b/usr/local/etc/cloud/cloud.cfg.d/02_growpart.cfg
@@ -1,0 +1,4 @@
+growpart:
+  mode: gpart
+  devices:
+    - /dev/da0p3

--- a/usr/local/etc/cloud/cloud.cfg.d/10_vulture.cfg
+++ b/usr/local/etc/cloud/cloud.cfg.d/10_vulture.cfg
@@ -1,0 +1,65 @@
+preserve_hostname: true
+datasource_list: [ConfigDrive, None]
+datasource:
+  ConfigDrive:
+    dsmode: local
+  Ec2:
+    strict_id: false
+    metadata_urls: [ 'http://169.254.169.254:80' ]
+    timeout: 5
+    max_wait: 10
+
+cloud_init_modules:
+ - migrator
+ - seed_random
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - users-groups
+ - ssh
+
+cloud_config_modules:
+ - ssh-import-id
+ - locale
+ - set-passwords
+ - timezone
+ - disable-ec2-metadata
+ - runcmd
+
+cloud_final_modules:
+ - package-update-upgrade-install
+ - write-files-deferred
+ - puppet
+ - chef
+ - mcollective
+ - salt-minion
+ - reset_rmc
+ - refresh_rmc_and_interface
+ - rightscale_userdata
+ - scripts-vendor
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - install-hotplug
+ - phone-home
+ - final-message
+ - power-state-change
+
+system_info:
+   # This will affect which distro class gets used
+   distro: freebsd
+   # WARNING 'vlt-adm' is set and enabled as default user/pass
+   # user SHOULD override the default password on cloud installations!
+   default_user:
+      name: vlt-adm
+      plain_text_passwd: vlt-adm
+      lock_passwd: false
+   network:
+      renderers: ['freebsd']


### PR DESCRIPTION
### Added
- [CLOUDINIT] new cloudinit specific configuration files to provide basic integration with optional py-38-cloud-init installation