### PR TITLE
Version 1.3.0

### DIFF
--- a/home/vlt-adm/bootstrap/mkjail-portal.sh
+++ b/home/vlt-adm/bootstrap/mkjail-portal.sh
@@ -107,6 +107,7 @@ jexec ${JAIL} /usr/sbin/pwd_mkdb -p /etc/master.passwd
 /usr/sbin/pkg -j ${JAIL} install -y openssl || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y tiff || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y libxcb || (/bin/echo "Fail !" ; exit 1)
+/usr/sbin/pkg -j ${JAIL} install -y python38 || (/bin/echo "Fail !" ; exit 1)
 
 # Jail NEEDS to be modified after system file modification !!!
 /bin/echo -n "Syncing jail..."

--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -1,70 +1,246 @@
 #!/bin/sh
 
+#############
+# variables #
+#############
+temp_dir=""
+resolve_strategy=""
+system_version=""
+keep_temp_dir=0
+do_update_system=1
+do_update_packages=1
+download_only=0
+use_dnssec=0
+clean_cache=0
 
-if [ "$(/usr/bin/id -u)" != "0" ]; then
-   /bin/echo "This script must be run as root" 1>&2
-   exit 1
-fi
+#############
+# functions #
+#############
+usage() {
+    echo "USAGE ${0} OPTIONS"
+    echo "OPTIONS:"
+    echo "	-D	only download packages/system updates in temporary dir (implies -T)"
+    echo "	-T	keep temporary directory"
+    echo "	-V	set a custom system update package (as specified by 'hbsd-update -v', only available on HBSD)"
+    echo "	-c	clean pkg cache and tempdir at the end of the script (incompatible with -T and -D)"
+    echo "	-d	use dnssec while downloading HardenedBSD updates (disabled by default)"
+    echo "	-u	do not update system/kernel, only update packages"
+    echo "	-s	do not update packages, only update system/kernel"
+    echo "	-t tmpdir	temporary directory to use (default is /tmp/vulture_update/, only available on HBSD)"
+    echo "	-r strategy	(non-interactive) resolve strategy to pass to hbsd-update script while upgrading system configuration files (see man etcupdate for more info)"
+    exit 1
+}
 
-if [ -f /etc/rc.conf.proxy ]; then
-    . /etc/rc.conf.proxy
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export ftp_proxy=${ftp_proxy}
-fi
+download_system_update() {
+    download_dir="$1"
 
+    if [ -f /usr/sbin/hbsd-update ] ; then
+        options=""
+        if [ $use_dnssec -eq 0 ]; then options="-d"; fi
+        if [ -n "$system_version" ]; then
+            # Add -U as non-last update versions cannot be verified
+            echo "[!] Custom version of system update selected, this version will be installed without signature verification!"
+            options="${options} -v $system_version -U"
+        fi        # Store (-t) and keep (-T) downloads to $download_dir for later use
+        # Do not install update yet (-f)
+        /usr/sbin/hbsd-update -t "$download_dir" -T -f $options
+        if [ $? -ne 0 ] ; then return 1 ; fi
+    else
+        /usr/sbin/freebsd-update --not-running-from-cron fetch > /dev/null
+        if [ $? -ne 0 ] ; then return 1 ; fi
+    fi
+}
 
 # Function used to use appropriate update binary
 update_system() {
-    temp_dir="$1"
+    download_dir="$1"
     jail="$2"
     if [ -f /usr/sbin/hbsd-update ] ; then
-        # If jail specified, do not download (use cache)
+        # If a jail is specified, execute update in it
         if [ -n "$jail" ] ; then options="-j $jail" ; fi
-        # Store (-t) and keep (-T) downloads to $temp_dir for later use
-        # Firstly try to extract previous download
-        /usr/sbin/hbsd-update -d -t "$temp_dir" -T -D $options
-        # If command failed, download the archive
-        if [ $? -ne 0 ] ; then /usr/sbin/hbsd-update -t "$temp_dir" -T $options ; fi
-        if [ $? -ne 0 ] ; then /usr/sbin/hbsd-update -d -t "$temp_dir" -T $options ; fi
+        if [ -n "$system_version" ]; then
+            # Add -U as non-last update versions cannot be verified
+            echo "[!] Custom version of system update selected, this version will be installed without signature verification!"
+            options="${options} -v $system_version -U"
+        fi
+        # Store (-t) and keep (-T) downloads to $download_dir for later use
+        # Previous download should be present in the 'download_dir' folder already
+        if [ -n "$resolve_strategy" ] ; then
+            # echo resolve strategy to hbsd-update for non-interactive resolution of conflicts in /etc/ via etcupdate
+            /bin/echo "$resolve_strategy" | /usr/sbin/hbsd-update -d -t "$download_dir" -T -D $options
+        else
+            /usr/sbin/hbsd-update -d -t "$download_dir" -T -D $options
+        fi
+        if [ $? -ne 0 ] ; then return 1 ; fi
     else
         # If jail, just install do not fetch
-        if [ -n "$jail" ] ; then options="-b /zroot/$jail" ; else option="fetch" ; fi
-        /usr/sbin/freebsd-update --not-running-from-cron $options install > /dev/null
+        if [ -n "$jail" ] ; then options="-b /zroot/$jail" ; fi
+        /usr/sbin/freebsd-update $options install > /dev/null
+        if [ $? -ne 0 ] ; then return 1 ; fi
     fi
 }
 
 
-# Create temporary directory for hbsd-update artifacts
-temp_dir="$(mktemp -d)"
+initialize() {
+    if [ "$(/usr/bin/id -u)" != "0" ]; then
+        /bin/echo "This script must be run as root" 1>&2
+        exit 1
+    fi
 
-# Disable secadm rules if on an HardenedBSD system
-if [ -f /usr/sbin/hbsd-update ] ; then
-    echo "[*] disabling root secadm rules"
-    /usr/sbin/service secadm stop || echo "Could not disable secadm rules"
+    trap finalize SIGINT
 
-    for jail in "mongodb" "apache" "portal"; do
-        echo "[*] [${jail}] disabling secadm rules"
-        /usr/sbin/jexec $jail /usr/sbin/service secadm stop || echo "Could not disable secadm rules"
-    done
+    if [ -f /etc/rc.conf.proxy ]; then
+        . /etc/rc.conf.proxy
+        export http_proxy=${http_proxy}
+        export https_proxy=${https_proxy}
+        export ftp_proxy=${ftp_proxy}
+    fi
+
+    # Create temporary directory if none specified
+    temp_dir=${temp_dir:="/tmp/vulture_update"}
+    mkdir -p $temp_dir || echo "Temp directory exists, keeping"
+
+    # Disable secadm rules if on an HardenedBSD system
+    if [ -f /usr/sbin/hbsd-update ] ; then
+        echo "[+] Disabling root secadm rules"
+        /usr/sbin/service secadm stop || echo "Could not disable secadm rules"
+        echo "[-] Done."
+
+        for jail in "mongodb" "apache" "portal"; do
+            echo "[+] [${jail}] Disabling secadm rules"
+            /usr/sbin/jexec $jail /usr/sbin/service secadm stop || echo "Could not disable secadm rules"
+            echo "[-] Done."
+        done
+    fi
+}
+
+
+finalize() {
+    # set default in case err_code is not specified
+    err_code=$1
+    err_message=$2
+    # does not work with '${1:=0}' if $1 is not set...
+    err_code=${err_code:=0}
+
+
+    if [ -n "$err_message" ]; then
+        echo ""
+        echo "[!] ${err_message}"
+        echo ""
+    fi
+
+    if [ $keep_temp_dir -eq 0 ]; then
+        echo "[+] Cleaning temporary dir..."
+        /bin/rm -rf $temp_dir
+        echo "[-] Done."
+    fi
+
+    # Re-enable secadm rules if on an HardenedBSD system
+    if [ -f /usr/sbin/hbsd-update ] ; then
+        echo "[+] Enabling root secadm rules"
+        /usr/sbin/service secadm start || echo "Could not enable secadm rules"
+        echo "[-] Done."
+
+        for jail in "mongodb" "apache" "portal"; do
+            echo "[+] [${jail}] Enabling secadm rules"
+            /usr/sbin/jexec $jail /usr/sbin/service secadm start || echo "Could not enable secadm rules"
+            echo "[-] Done."
+        done
+    fi
+
+    exit $err_code
+}
+
+
+####################
+# parse parameters #
+####################
+while getopts 'hDTV:cdust:r:' opt; do
+    case "${opt}" in
+        D)  download_only=1;
+            keep_temp_dir=1;
+            ;;
+        T)  keep_temp_dir=1;
+            ;;
+        V)  system_version="${OPTARG}";
+            ;;
+        c)  clean_cache=1;
+            ;;
+        d)  use_dnssec=1;
+            ;;
+        u)  do_update_system=0;
+            ;;
+        s)  do_update_packages=0;
+            ;;
+        t)  temp_dir="${OPTARG}";
+            ;;
+        r)  resolve_strategy="${OPTARG}";
+            ;;
+        *)  usage;
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ $clean_cache -gt 0 -a $keep_temp_dir -gt 0 -o $clean_cache -gt 0 -a $download_only -gt 0 ]; then
+    echo "[!] Cannot activate -c if -D or -T are set"
+    exit 1
 fi
 
-IGNORE_OSVERSION="yes" /usr/sbin/pkg update -f
-echo "Updating system..."
-update_system "$temp_dir"
-echo "Ok."
+initialize
+
+if [ $do_update_packages -gt 0 ]; then
+    IGNORE_OSVERSION="yes" /usr/sbin/pkg update -f || finalize 1 "Could not update list of packages"
+fi
+
+if [ $download_only -gt 0 ]; then
+    if [ $do_update_packages -gt 0 ]; then
+        # Fetch updated packages for root system
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg fetch -yu || finalize 1 "Failed to download new packages"
+        # fetch updated packages for each jail
+        for jail in "haproxy" "apache" "portal" "mongodb" "redis" "rsyslog" ; do
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg -j $jail update -f || finalize 1 "Could not update list of packages for jail ${jail}"
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg -j $jail fetch -yu || finalize 1 "Failed to download new packages for jail ${jail}"
+        done
+    fi
+    if [ $do_update_system -gt 0 ]; then
+        download_system_update ${temp_dir} || finalize 1 "Failed to download system upgrades"
+    fi
+    # exit here, everything has been downloaded
+    finalize
+fi
+
+if [ $do_update_system -gt 0 ]; then
+    if [ ! -f ${temp_dir}/update.tar ]; then
+        /bin/echo "[+] Downloading system updates..."
+        download_system_update ${temp_dir} || finalize 1 "Failed to download system upgrades"
+        /bin/echo "[-] Done."
+    fi
+    /bin/echo "[+] Updating system..."
+    update_system ${temp_dir} || finalize 1 "Failed to install system upgrades"
+    /bin/echo "[-] Done."
+fi
 
 # If no argument or jail asked
 for jail in "haproxy" "redis" "mongodb" "rsyslog" ; do
     if [ -z "$1" -o "$1" == "$jail" ] ; then
-        echo "[-] Updating $jail..."
-        echo "[-] Updating jail $jail base system files..."
-        update_system "$temp_dir" "$jail"
-        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j "$jail" update -f
-        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j "$jail" upgrade -y
-        # Upgrade vulture-$jail AFTER, in case of "pkg -j $jail upgrade" has removed some permissions... (like redis)
-        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y "vulture-$jail"
-        echo "Ok."
+        /bin/echo "[+] Updating $jail..."
+
+        if [ $do_update_system -gt 0 ]; then
+            /bin/echo "[+] Updating jail $jail base system files..."
+            update_system "$temp_dir" "$jail" || finalize 1 "Failed to install system upgrades in jail ${jail}"
+            echo "[-] Ok."
+        fi
+
+        if [ $do_update_packages -gt 0 ]; then
+            /bin/echo "[+] Updating jail $jail packages..."
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg -j "$jail" update -f || finalize 1 "Could not update list of packages for jail ${jail}"
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg -j "$jail" upgrade -y || finalize 1 "Could not upgrade packages for jail ${jail}"
+            # Upgrade vulture-$jail AFTER, in case of "pkg -j $jail upgrade" has removed some permissions... (like redis)
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y "vulture-$jail" || finalize 1 "Could not upgrade vulture-${jail}"
+            echo "[-] Ok."
+        fi
+
         case "$jail" in
             rsyslog)
                 /usr/sbin/jexec "$jail" /usr/sbin/service rsyslogd restart
@@ -96,69 +272,68 @@ for jail in "haproxy" "redis" "mongodb" "rsyslog" ; do
                 /usr/sbin/jexec "$jail" /usr/sbin/service "$jail" restart
                 ;;
         esac
-        echo "[+] $jail updated."
+        echo "[-] $jail updated."
     fi
 done
 
 # If no argument, or Darwin
 if [ -z "$1" -o "$1" == "darwin" ] ; then
-    /usr/sbin/service darwin stop
-    echo "[-] Updating darwin..."
-    if [ "$(/usr/sbin/pkg query "%v" darwin)" == "1.2.1-2" ]; then
-        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -fy darwin
-    else
-        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y darwin
+    if [ $do_update_packages -gt 0 ]; then
+        /usr/sbin/service darwin stop
+        echo "[+] Updating darwin..."
+        if [ "$(/usr/sbin/pkg query "%v" darwin)" == "1.2.1-2" ]; then
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -fy darwin || finalize 1 "Failed to upgrade package Darwin"
+        else
+            IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y darwin || finalize 1 "Failed to upgrade package Darwin"
+        fi
+        echo "[-] Darwin updated, starting service"
+        /usr/sbin/service darwin start
     fi
-    echo "[+] Darwin updated, starting service"
-    /usr/sbin/service darwin start
 fi
 
 # No parameter, or gui
 if [ -z "$1" -o "$1" == "gui" ] ; then
-    echo "[-] Updating GUI..."
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y vulture-gui
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg -j apache update -f
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg -j portal update -f
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg -j apache upgrade -y
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg -j portal upgrade -y
-    echo "[-] Updating jail base system files..."
-    update_system "$temp_dir" "apache"
-    update_system "$temp_dir" "portal"
-    echo "Ok."
+    echo "[+] Updating GUI..."
+    if [ $do_update_packages -gt 0 ]; then
+        echo "[+] Updating apache and portal jails' packages..."
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y vulture-gui  || finalize 1 "Failed to upgrade package vulture-gui"
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j apache update -f || finalize 1 "Failed to update the list of packages for the apache jail"
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j portal update -f || finalize 1 "Failed to update the list of packages for the portal jail"
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j apache upgrade -y || finalize 1 "Failed to upgrade packages in the apache jail"
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg -j portal upgrade -y || finalize 1 "Failed to upgrade packages in the portal jail"
+        echo "[-] Ok."
+    fi
+
+    if [ $do_update_system -gt 0 ]; then
+        echo "[+] Updating jail apache base system files..."
+        update_system "$temp_dir" "apache" || finalize 1 "Failed to install system upgrades in jail apache"
+        echo "[-] Ok."
+        echo "[+] Updating jail portal base system files..."
+        update_system "$temp_dir" "portal" || finalize 1 "Failed to install system upgrades in jail portal"
+        echo "[-] Ok."
+    fi
     /usr/sbin/jexec apache /usr/sbin/service apache24 restart
     /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
-    echo "[+] GUI updated."
+    echo "[-] GUI updated."
 fi
 
 # If no parameter provided, upgrade vulture-base
 if [ -z "$1" ] ; then
-    echo "[-] Updating vulture-base ..."
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y vulture-base
-
-    echo "[+] Vulture-base updated"
+    if [ $do_update_packages -gt 0 ]; then
+        echo "[+] Updating vulture-base ..."
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y vulture-base || finalize 1 "Failed to upgrade vulture-base"
+        echo "[-] Vulture-base updated"
+    fi
 fi
 
 
 # If no argument - update all
 if [ -z "$1" ] ; then
-    echo "[-] Updating all packages..."
-    # First upgrade libevent & gnutls independently to prevent removing of vulture-base (don't know why...)
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y libevent
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y gnutls
-    # Then, upgrade all packages
-    IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y
-    echo "[+] All packages updated"
-fi
-
-# Re-enable secadm rules if on an HardenedBSD system
-if [ -f /usr/sbin/hbsd-update ] ; then
-    echo "[*] enabling root secadm rules"
-    /usr/sbin/service secadm start || echo "Could not enable secadm rules"
-
-    for jail in "mongodb" "apache" "portal"; do
-        echo "[*] [${jail}] enabling secadm rules"
-        /usr/sbin/jexec $jail /usr/sbin/service secadm start || echo "Could not enable secadm rules"
-    done
+    if [ $do_update_packages -gt 0 ]; then
+        echo "[+] Updating all packages on system..."
+        IGNORE_OSVERSION="yes" /usr/sbin/pkg upgrade -y  || finalize 1 "Error while upgrading packages"
+        echo "[-] All packages updated"
+    fi
 fi
 
 # Do not start vultured if the node is not installed
@@ -166,5 +341,15 @@ if [ -f /home/vlt-os/vulture_os/.node_ok ]; then
     /usr/sbin/service vultured restart
 fi
 
-# Remove temporary folder for system updates
-/bin/rm -rf $temp_dir
+if [ $clean_cache -gt 0 ]; then
+    echo "[+] Cleaning pkg cache..."
+    /usr/sbin/pkg clean -ay
+    echo "[-] Done."
+    for jail in "haproxy" "apache" "portal" "mongodb" "redis" "rsyslog" ; do
+        echo "[+] Cleaning pkg cache in jail ${jail}..."
+        /usr/sbin/pkg -j $jail clean -ay
+        echo "[-] Done."
+    done
+fi
+
+finalize

--- a/usr/local/etc/cloud/cloud.cfg.d/02_growpart.cfg
+++ b/usr/local/etc/cloud/cloud.cfg.d/02_growpart.cfg
@@ -1,0 +1,4 @@
+growpart:
+  mode: gpart
+  devices:
+    - /dev/da0p3

--- a/usr/local/etc/cloud/cloud.cfg.d/10_vulture.cfg
+++ b/usr/local/etc/cloud/cloud.cfg.d/10_vulture.cfg
@@ -1,0 +1,65 @@
+preserve_hostname: true
+datasource_list: [ConfigDrive, None]
+datasource:
+  ConfigDrive:
+    dsmode: local
+  Ec2:
+    strict_id: false
+    metadata_urls: [ 'http://169.254.169.254:80' ]
+    timeout: 5
+    max_wait: 10
+
+cloud_init_modules:
+ - migrator
+ - seed_random
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - users-groups
+ - ssh
+
+cloud_config_modules:
+ - ssh-import-id
+ - locale
+ - set-passwords
+ - timezone
+ - disable-ec2-metadata
+ - runcmd
+
+cloud_final_modules:
+ - package-update-upgrade-install
+ - write-files-deferred
+ - puppet
+ - chef
+ - mcollective
+ - salt-minion
+ - reset_rmc
+ - refresh_rmc_and_interface
+ - rightscale_userdata
+ - scripts-vendor
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - install-hotplug
+ - phone-home
+ - final-message
+ - power-state-change
+
+system_info:
+   # This will affect which distro class gets used
+   distro: freebsd
+   # WARNING 'vlt-adm' is set and enabled as default user/pass
+   # user SHOULD override the default password on cloud installations!
+   default_user:
+      name: vlt-adm
+      plain_text_passwd: vlt-adm
+      lock_passwd: false
+   network:
+      renderers: ['freebsd']


### PR DESCRIPTION
### Fixed
- [MKJAIL][PORTAL] add missing python38 package in the portal jail during jail creation

### Changed
- [SYSTEM][UPGRADE] Complete rework of update_system.sh
  - ability to only download packages and system upgrades on a temporary directory
  - ability to remove/keep temporary directory used during upgrade
  - ability to use a custom version while upgrading system (compatible with HardenedBSD only)
  - ability to clean pkg cache (system and jails) after a successful upgrade
  - ability to specify if DNSSEC should be used during system upgrade (default NO)
  - ability to only upgrade packages, not system (equivalent to update_system_lite)
  - ability to only upgrade system and jails, not packages
  - ability to specify a custom temporary directory
  - ability to specify an 'automatic' resolution process during HardenedBSD system upgrades (etcupdate resolve strategy) for non-interactive upgrades
  - WARNING: the script no longer tries system upgrade package validation with DNSSEC, user SHOULD use -d to activate DNSSEC validation when necessary
  - OBSOLETE: update_system_lite.sh will be obsoleted in the next release

### Added
- [CLOUDINIT] basic configuration files for cloud-init integration