### PR TITLE
UPDATE_SYSTEM::FIXED:: use 'yes' util instead of simple 'echo' during non-interactive resolve-strategy in system updates

### DIFF
--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -67,7 +67,7 @@ update_system() {
         # Previous download should be present in the 'download_dir' folder already
         if [ -n "$resolve_strategy" ] ; then
             # echo resolve strategy to hbsd-update for non-interactive resolution of conflicts in /etc/ via etcupdate
-            /bin/echo "$resolve_strategy" | /usr/sbin/hbsd-update -d -t "$download_dir" -T -D $options
+            /usr/bin/yes "$resolve_strategy" | /usr/sbin/hbsd-update -d -t "$download_dir" -T -D $options
         else
             /usr/sbin/hbsd-update -d -t "$download_dir" -T -D $options
         fi


### PR DESCRIPTION
For some hbsd-update executions, etcupdate asks for the resolve strategy for each file with a conflict
the use of 'echo' in that case is not sufficient, and using 'yes' instead ensures all etcupdate questions during hbsd-update are answered