### PR TITLE
Removed pkg install vulture-libtensorflow

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,7 +36,6 @@ And create **repository configuration** file : <br>
 Then, **install** required **packages** : <br>
 `pkg update` <br>
 `pkg install -y open-vm-tools-nox11 wget libucl secadm secadm-kmod` <br>
-`pkg install -y vulture-libtensorflow` <br>
 `pkg install -y vulture-haproxy` <br>
 `pkg install -y vulture-rsyslog` <br>
 `pkg install -y vulture-mongodb` <br>


### PR DESCRIPTION
This merge request is dependent on code_cleanup : https://github.com/VultureProject/vulture-base/pull/82
## Changes
- There is no more vulture-libtensorflow dependency hence removal of install instruction from BUILDING.md