### PR TITLE
Version 1.3.2

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -36,7 +36,6 @@ And create **repository configuration** file : <br>
 Then, **install** required **packages** : <br>
 `pkg update` <br>
 `pkg install -y open-vm-tools-nox11 wget libucl secadm secadm-kmod` <br>
-`pkg install -y vulture-libtensorflow` <br>
 `pkg install -y vulture-haproxy` <br>
 `pkg install -y vulture-rsyslog` <br>
 `pkg install -y vulture-mongodb` <br>


### PR DESCRIPTION
### Removed
- [DOC] Do not specify installing vulture-libtensorflow package in installation instructions
- [DEPENDENCIES] do not depend on vulture-libtensorflow anymore