### PR TITLE
 GUI::Transition from 'apache' to 'gunicorn'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Removed
+- [JAIL] [APACHE] Disable and uninstall apache from jail
+### Added
+- [JAIL] [APACHE] Install nginx and gunicorn in the apache jail
+- [JAIL] [APACHE] Ensure python is installed in the apache jail
+- [SYSTEM] Create a new /var/sockets/gui folder and mount it RW in the apache jail
+- [SUDO] Allow vlt-os to manage gunicorn/nginx services
+### Changed
+- [UPDATE_SYSTEM] stop/start/reload nginx/gunicorn during system updates
+- [LOGROTATE] reload nginx and gunicorn in the apache jail after rotating gui logs
+
+
 ## [2.0.4] - 2022-11-21
 ### Added
 - [CLOUD_INIT] Default logging configuration

--- a/home/vlt-adm/bootstrap/mkjail-apache.sh
+++ b/home/vlt-adm/bootstrap/mkjail-apache.sh
@@ -99,6 +99,7 @@ jexec ${JAIL} /usr/sbin/pwd_mkdb -p /etc/master.passwd
 /usr/sbin/pkg -j ${JAIL} install -y libucl || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y secadm secadm-kmod || (/bin/echo "Fail !" ; exit 1)
 /usr/sbin/pkg -j ${JAIL} install -y liblognorm || (/bin/echo "Fail !" ; exit 1)
+/usr/sbin/pkg -j ${JAIL} install -y lang/python || (/bin/echo "Fail !" ; exit 1)
 
 # Needed dependency for haproxy package copied from vulture-haproxy
 /usr/sbin/pkg -j ${JAIL} install -y pcre2 || (/bin/echo "Fail !" ; exit 1)

--- a/home/vlt-adm/system/hostname.sh
+++ b/home/vlt-adm/system/hostname.sh
@@ -58,7 +58,8 @@ if [ -f /tmp/bsdinstall_etc/rc.conf.hostname ]; then
         /home/vlt-os/env/bin/python /home/vlt-os/scripts/pki.py
 
         # Apache: Hostname change has no impact
-        /usr/sbin/jexec apache /usr/sbin/service apache24 restart
+        /usr/sbin/jexec apache /usr/sbin/service gunicorn restart
+        /usr/sbin/jexec apache /usr/sbin/service nginx restart
         /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
 
         # MongoDB is restarted "as this"

--- a/home/vlt-adm/system/update_system.sh
+++ b/home/vlt-adm/system/update_system.sh
@@ -358,7 +358,8 @@ if [ -z "$1" -o "$1" == "gui" ] ; then
         update_system "$temp_dir" "portal" || finalize 1 "Failed to install system upgrades in jail portal"
         echo "[-] Ok."
     fi
-    /usr/sbin/jexec apache /usr/sbin/service apache24 restart
+    /usr/sbin/jexec apache /usr/sbin/service gunicorn restart
+    /usr/sbin/jexec apache /usr/sbin/service nginx restart
     /usr/sbin/jexec portal /usr/sbin/service gunicorn restart
     echo "[-] GUI updated."
 fi

--- a/usr/local/etc/logrotate.d/vulture.conf
+++ b/usr/local/etc/logrotate.d/vulture.conf
@@ -68,7 +68,8 @@
 	sharedscripts  # execute script one time for all logs
 	postrotate
 	    /usr/sbin/service vultured restart
-	    /usr/sbin/jexec apache /usr/sbin/service apache24 reload
+	    /usr/sbin/jexec apache /usr/sbin/service gunicorn reload
+	    /usr/sbin/jexec apache /usr/sbin/service nginx reload
 	    /usr/sbin/jexec portal /usr/sbin/service gunicorn reload
 	endscript
 }

--- a/usr/local/etc/sudoers.d/vulture_sudoers
+++ b/usr/local/etc/sudoers.d/vulture_sudoers
@@ -12,11 +12,14 @@ vlt-os ALL=NOPASSWD:/usr/sbin/service routing restart
 
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec redis /usr/sbin/service redis onestatus
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec mongodb /usr/sbin/service mongod onestatus
-vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 onestatus
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service gunicorn onestatus
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service nginx onestatus
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec portal /usr/sbin/service gunicorn onestatus
 
-vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 reload
-vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service apache24 restart
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service gunicorn reload
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service gunicorn restart
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service nginx reload
+vlt-os ALL=NOPASSWD:/usr/sbin/jexec apache /usr/sbin/service nginx restart
 
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec haproxy /usr/sbin/service haproxy onestatus
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec haproxy /usr/sbin/service haproxy start


### PR DESCRIPTION
### Changed
 - Changes in apache jail's template
### Added
 - Nginx as reverse proxy and static files serving
### Deleted
 - Any services in relation with Apache