### PR TITLE
fix(sudoers): Allow '-f' flag when removing filebeat configs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- [SUDOERS] Allow '-f' flag when removing filebeat configs
 
 
 ## [2.1.14] - 2025-03-28

--- a/usr/local/etc/sudoers.d/vulture_sudoers
+++ b/usr/local/etc/sudoers.d/vulture_sudoers
@@ -42,7 +42,7 @@ vlt-os ALL=NOPASSWD:/usr/sbin/jexec ^rsyslog \/usr\/sbin\/service filebeat onest
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec ^rsyslog \/usr\/sbin\/service filebeat start( [0-9]+)*$
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec ^rsyslog \/usr\/sbin\/service filebeat stop( [0-9]+)*$
 vlt-os ALL=NOPASSWD:/usr/sbin/jexec ^rsyslog \/usr\/sbin\/service filebeat reload( [0-9]+)*$
-vlt-os ALL=NOPASSWD:/bin/rm ^\/usr\/local\/etc\/filebeat\/[a-zA-Z0-9._-]+$
+vlt-os ALL=NOPASSWD:/bin/rm ^(-f )?\/usr\/local\/etc\/filebeat\/[a-zA-Z0-9._-]+$
 
 vlt-os ALL=NOPASSWD:/usr/sbin/service strongswan reload
 vlt-os ALL=NOPASSWD:/usr/sbin/service strongswan restart


### PR DESCRIPTION
### Fixed
- [SUDOERS] Allow '-f' flag when removing filebeat configs