### PR TITLE
changed(admin): use vlt-admin command for update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Changed
+- [ADMIN] Use new vlt-admin command instead of update_system.sh
+- [SUDOERS] Allow vlt-admin command without password prompt
 
 
 ## [2.1.19] - 2026-03-06

--- a/home/vlt-adm/admin.sh
+++ b/home/vlt-adm/admin.sh
@@ -120,7 +120,8 @@ do
                     ;;
                 "update")
                     check_jails
-                    /usr/local/bin/sudo /home/vlt-adm/system/update_system.sh
+                    /usr/local/bin/sudo /usr/local/bin/vlt-admin upgrade-os -B all
+                    /usr/local/bin/sudo /usr/local/bin/vlt-admin upgrade-pkg
                     ;;
                 "exit")
                     break

--- a/usr/local/etc/sudoers.d/base_sudoers
+++ b/usr/local/etc/sudoers.d/base_sudoers
@@ -6,6 +6,7 @@ vlt-adm ALL=NOPASSWD:/usr/sbin/kbdmap
 vlt-adm ALL=NOPASSWD:/usr/sbin/ntpdate
 vlt-adm ALL=NOPASSWD:/bin/hostname
 
+vlt-adm ALL=NOPASSWD:/usr/local/bin/vlt-admin
 vlt-adm ALL=NOPASSWD:/home/vlt-adm/system/write_ntp.sh
 vlt-adm ALL=NOPASSWD:/home/vlt-adm/system/write_aliases.sh
 vlt-adm ALL=NOPASSWD:/home/vlt-adm/system/proxy.sh


### PR DESCRIPTION
### Changed
- [ADMIN] Use new vlt-admin command instead of update_system.sh
- [SUDOERS] Allow vlt-admin command without password prompt